### PR TITLE
Unpyc3 Decompiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Utility/unpyc37"]
+	path = Utility/unpyc37
+	url = https://github.com/andrew-tavera/unpyc37.git

--- a/Utility/helpers_unpyc3.py
+++ b/Utility/helpers_unpyc3.py
@@ -1,0 +1,31 @@
+import io
+
+try:
+    import Utility.unpyc37.unpyc3
+    UNPYC37_AVAILABLE = True
+except:
+    pass
+
+
+def unpyc3_decompile(dest_file_path: str, src_file_path: str) -> bool:
+    """
+    Decompiles a python file via unpyc3
+
+    :param dest_file_path: Path of the output file
+    :param src_file_path:  Path of the source file to decompile
+    :return: boolean to indicate whether it was successful or not
+    """
+
+    if not UNPYC37_AVAILABLE:
+        return False
+
+    try:
+        suite = Utility.unpyc37.unpyc3.decompile(src_file_path)
+        with io.open(dest_file_path, 'w') as output_file:
+            for statement in suite.statements:
+                output_file.write(str(statement))
+                output_file.write(str('\n'))
+    except Exception as e:
+        return False
+
+    return True

--- a/decompile.py
+++ b/decompile.py
@@ -18,7 +18,7 @@ import sys
 
 from Utility.helpers_decompile import decompile_pre, decompile_zips, decompile_print_totals
 from Utility.helpers_path import ensure_path_created, remove_dir
-from settings import gameplay_folder_data, gameplay_folder_game, projects_python_path
+from settings import gameplay_folder_data, gameplay_folder_game, projects_python_path, decompiler_name
 
 if os.path.exists(projects_python_path):
     print("This will wipe out the old decompilation at: " + projects_python_path)
@@ -33,7 +33,7 @@ remove_dir(projects_python_path)
 ensure_path_created(projects_python_path)
 
 # Do a pre-setup
-decompile_pre()
+decompile_pre(decompiler_name)
 
 # Decompile all zips to the python projects folder
 print("")
@@ -42,8 +42,8 @@ print("THIS WILL SERIOUSLY TAKE A VERY LONG TIME!!! " +
       "Additionally many files will not decompile properly which is normal.")
 print("")
 
-decompile_zips(gameplay_folder_data, projects_python_path)
-decompile_zips(gameplay_folder_game, projects_python_path)
+decompile_zips(gameplay_folder_data, projects_python_path, decompiler_name)
+decompile_zips(gameplay_folder_game, projects_python_path, decompiler_name)
 
 # Print final statistics
 decompile_print_totals()

--- a/settings.py.orig
+++ b/settings.py.orig
@@ -39,6 +39,9 @@ game_folder = os.path.join('C:', os.sep, 'Program Files (x86)', 'Origin Games', 
 # You do not need to use PyCharm at all or the professional version, ignore this setting if you are not
 pycharm_pro_folder = os.path.join('C:', os.sep, 'Program Files', 'JetBrains', 'PyCharm 2020.2.2')
 
+# The decompiler to use ['unpyc3', 'decompyle3', 'uncompyle6']
+decompiler = 'unpyc3'
+
 # ####################################################
 # Settings that you can but generally won't change
 # ####################################################


### PR DESCRIPTION
Currently, the decompiler code is hardcoded to use uncompyle6. This pull requests adds the functionality to switch between 3 possible decompilers. The supported decompilers are unpyc3, decompyle3, and uncompyle6.

- Added in a submodule to unpyc37 which is used instead of unpyc3
- Added in functionality to handle unpyc3 for decompiling since it's called through a module rather than an executable
- Updated code to support setting the decompiler you want to use

#2 